### PR TITLE
Proposal to add the option to use event class names as transition labels in PlantUML export

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -873,7 +873,7 @@ to [PlantUML state diagram](https://plantuml.com/en/state-diagram).
 
 ```kotlin
 val machine = createStateMachine(scope) { /* ... */ }
-println(machine.exportToPlantUml())
+println(machine.exportToPlantUml(showEventLabels = false))
 ```
 
 Copy/paste resulting output to [Plant UML online editor](http://www.plantuml.com/plantuml/)


### PR DESCRIPTION
Added this so that PlantUML export has the option of including Event Class names for transition labels,
especially in smaller state machines where the transition isn't explicitly named.

Set default to false so it shouldn't change any behavior for existing code.